### PR TITLE
Add OnchainKit to homepage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import '@coinbase/onchainkit/styles.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains';
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+      chain={base}
+    >
+      {children}
+    </OnchainKitProvider>
+  );
+}


### PR DESCRIPTION
This pull request adds OnchainKit to the homepage by implementing the following changes:

1. Install OnchainKit package
2. Set up OnchainKit provider
3. Wrap the app with the OnchainKit provider
4. Import OnchainKit styles

Changes:
- Added `@import '@coinbase/onchainkit/styles.css';` to `app/globals.css`
- Created `app/providers.tsx` to set up the OnchainKit provider
- Modified `app/layout.tsx` to wrap the app with the OnchainKit provider

To complete the setup:
1. Run `npm install @coinbase/onchainkit`
2. Create a `.env` file in the project root and add your OnchainKit API key:
   ```
   NEXT_PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY
   ```
3. Replace `YOUR_CLIENT_API_KEY` with the actual API key from the Coinbase Developer Platform.

These changes will integrate OnchainKit into the project, allowing for easier blockchain interactions and Web3 functionality on the homepage.