### PR TITLE
Implement OnchainKit with Next.js

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import '@coinbase/onchainkit/styles.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+      chain={base} // add baseSepolia for testing
+    >
+      {children}
+    </OnchainKitProvider>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@coinbase/onchainkit": "^0.34.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.513.0",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "wagmi": "^2.12.31"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
This pull request implements OnchainKit with Next.js as requested. The changes include:

1. Installing OnchainKit package
2. Adding OnchainKit styles to globals.css
3. Creating a Providers component to wrap the app with OnchainKitProvider
4. Updating the RootLayout to use the Providers component
5. Adding necessary dependencies to package.json

These changes will enable the use of OnchainKit components and functionality in the project.

To complete the setup, please make sure to:
1. Create a `.env` file in the project root and add your OnchainKit API key:
   ```
   NEXT_PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY
   ```
2. Create a `providers.tsx` file in the `app` directory with the following content:
   ```tsx
   'use client';

   import type { ReactNode } from 'react';
   import { OnchainKitProvider } from '@coinbase/onchainkit';
   import { base } from 'wagmi/chains';

   export function Providers({ children }: { children: ReactNode }) {
     return (
       <OnchainKitProvider
         apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
         chain={base}
       >
         {children}
       </OnchainKitProvider>
     );
   }
   ```

After merging this pull request, you'll be able to use OnchainKit components in your Next.js project.