### PR TITLE
Add OnchainKit integration to the home page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import '@coinbase/onchainkit/styles.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,35 @@
 import Image from "next/image";
+import { Address, Avatar, Name, Identity } from '@coinbase/onchainkit/identity';
+import { ConnectWallet, Wallet, WalletDropdown, WalletDropdownLink, WalletDropdownDisconnect } from '@coinbase/onchainkit/wallet';
 
 export default function Home() {
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+        <div className="w-full flex justify-end mb-4">
+          <Wallet>
+            <ConnectWallet>
+              <Avatar className="h-6 w-6" />
+              <Name />
+            </ConnectWallet>
+            <WalletDropdown>
+              <Identity className="px-4 pt-3 pb-2" hasCopyAddressOnClick>
+                <Avatar />
+                <Name />
+                <Address />
+              </Identity>
+              <WalletDropdownLink
+                icon="wallet"
+                href="https://keys.coinbase.com"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Wallet
+              </WalletDropdownLink>
+              <WalletDropdownDisconnect />
+            </WalletDropdown>
+          </Wallet>
+        </div>
         <Image
           className="dark:invert"
           src="/next.svg"

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+      chain={base} // add baseSepolia for testing
+    >
+      {children}
+    </OnchainKitProvider>
+  );
+}


### PR DESCRIPTION
This pull request adds OnchainKit integration to the project's home page. The changes include:

1. Installing and configuring OnchainKit with Next.js
2. Adding the necessary providers and wrapping the app with them
3. Importing OnchainKit styles
4. Implementing OnchainKit components on the home page

## Changes:

### 1. `app/globals.css`:
- Added import for OnchainKit styles

### 2. `app/layout.tsx`:
- Imported and wrapped the app with `Providers` component

### 3. `app/page.tsx`:
- Added OnchainKit components to the home page:
  - Wallet connection button
  - User identity display
  - Wallet dropdown with links and disconnect option

These changes will enable users to connect their wallets and interact with blockchain functionality directly from the home page.

## Testing:
Please test the following:
1. Ensure the app builds and runs without errors
2. Verify that the wallet connection button appears on the home page
3. Test connecting a wallet and check if the user's identity is displayed correctly
4. Confirm that the wallet dropdown works and shows the correct options

## Note:
Make sure to set up the `NEXT_PUBLIC_ONCHAINKIT_API_KEY` in the `.env` file with your Client API Key from the Coinbase Developer Platform.