### PR TITLE
Integrate OnchainKit with Next.js

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import '@coinbase/onchainkit/styles.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from './providers';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+      chain={base} // add baseSepolia for testing
+    >
+      {children}
+    </OnchainKitProvider>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@coinbase/onchainkit": "^0.35.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.513.0",


### PR DESCRIPTION
This pull request integrates OnchainKit with our Next.js project. Here's a summary of the changes:

1. Installed OnchainKit package
2. Added OnchainKit styles to globals.css
3. Created a Providers component to wrap the app with OnchainKitProvider
4. Updated RootLayout to use the new Providers component

## Changes Made

### 1. Package Installation
- Added `@coinbase/onchainkit` to dependencies in `package.json`

### 2. Styles Integration
- Updated `app/globals.css` to import OnchainKit styles:
  ```css
  @import '@coinbase/onchainkit/styles.css';
  ```

### 3. Providers Setup
- Created a new file `app/providers.tsx` (not shown in the diff, but mentioned in the instructions) to set up the OnchainKitProvider.

### 4. RootLayout Update
- Modified `app/layout.tsx` to wrap the children with the new Providers component:
  ```tsx
  import { Providers } from './providers';
  // ...
  <Providers>
    {children}
  </Providers>
  ```

## Next Steps
1. Create a `.env` file in the project root and add the OnchainKit API key:
   ```
   NEXT_PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY
   ```
2. Replace `YOUR_CLIENT_API_KEY` with the actual API key from the Coinbase Developer Platform.
3. Update the `providers.tsx` file to use the correct chain (base or baseSepolia for testing).

## Testing
Please test the integration to ensure that OnchainKit components work as expected in the application.

## Documentation
For more details on using OnchainKit with Next.js, refer to the [OnchainKit Next.js Installation Guide](https://docs.base.org/builderkits/onchainkit/installation/nextjs).