### PR TITLE
Integrate OnchainKit with Next.js

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import '@coinbase/onchainkit/styles.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+      chain={base} // add baseSepolia for testing
+    >
+      {children}
+    </OnchainKitProvider>
+  );
+}


### PR DESCRIPTION
This pull request integrates OnchainKit with our Next.js project as requested. Here's a summary of the changes:

1. Added OnchainKit styles to `globals.css`
2. Created a new `providers.tsx` file to set up the OnchainKitProvider
3. Wrapped the app with the Providers component in `layout.tsx`

To complete the integration, please follow these additional steps:

1. Install OnchainKit:
   ```bash
   npm install @coinbase/onchainkit
   ```

2. Create a `.env` file in the project root and add your OnchainKit API key:
   ```
   NEXT_PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY
   ```

3. Create the `providers.tsx` file with the following content:
   ```tsx
   'use client';

   import type { ReactNode } from 'react';
   import { OnchainKitProvider } from '@coinbase/onchainkit';
   import { base } from 'wagmi/chains';

   export function Providers({ children }: { children: ReactNode }) {
     return (
       <OnchainKitProvider
         apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
         chain={base}
       >
         {children}
       </OnchainKitProvider>
     );
   }
   ```

These changes set up the foundation for using OnchainKit in our Next.js project. You can now start using OnchainKit components and features in your application.