### PR TITLE
Integrate OnchainKit with Next.js

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import '@coinbase/onchainkit/styles.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from './providers';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+      chain={base} // add baseSepolia for testing
+    >
+      {children}
+    </OnchainKitProvider>
+  );
+}


### PR DESCRIPTION
This pull request integrates OnchainKit with our Next.js project as requested. Here's a summary of the changes:

1. Added OnchainKit styles to `globals.css`
2. Created a new `Providers` component to wrap the app with `OnchainKitProvider`
3. Updated `layout.tsx` to use the new `Providers` component

These changes set up the basic infrastructure for using OnchainKit in our project. Next steps would include:

- Obtaining a Client API Key from the Coinbase Developer Platform
- Creating a `.env` file with the API key
- Implementing specific OnchainKit components as needed in our pages/components

Please review the changes and let me know if any adjustments are needed.