### PR TITLE
Integrate OnchainKit with Next.js

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,4 @@
+@import '@coinbase/onchainkit/styles.css';
 @import "tailwindcss";
 @import "tw-animate-css";
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+      chain={base} // add baseSepolia for testing
+    >
+      {children}
+    </OnchainKitProvider>
+  );
+}


### PR DESCRIPTION
This pull request integrates OnchainKit with our Next.js project. Here's a summary of the changes:

1. Added OnchainKit styles to `globals.css`
2. Created a new `Providers` component to wrap the app with `OnchainKitProvider`
3. Updated `layout.tsx` to use the new `Providers` component

These changes will enable us to use OnchainKit components and functionality throughout our application.

### Details:

- In `globals.css`, we've imported OnchainKit styles:
  ```css
  @import '@coinbase/onchainkit/styles.css';
  ```

- We've created a new `providers.tsx` file (not shown in the diff, but mentioned in the instructions) to set up the `OnchainKitProvider`.

- In `layout.tsx`, we've imported and implemented the `Providers` component:
  ```tsx
  import { Providers } from "./providers";
  
  // ...
  
  <Providers>
    {children}
  </Providers>
  ```

### Next steps:
1. Ensure that the `NEXT_PUBLIC_ONCHAINKIT_API_KEY` is set in the `.env` file with the correct API key from the Coinbase Developer Platform.
2. Install the `@coinbase/onchainkit` package if not already done:
   ```
   npm install @coinbase/onchainkit
   ```
3. Start using OnchainKit components in our pages and components as needed.

Please review these changes and let me know if any adjustments are required.