### PR TITLE
Integrate OnchainKit with Next.js

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import '@coinbase/onchainkit/styles.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from './providers';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
+      chain={base} // add baseSepolia for testing
+    >
+      {children}
+    </OnchainKitProvider>
+  );
+}


### PR DESCRIPTION
This pull request integrates OnchainKit with our Next.js project as requested. Here's a summary of the changes:

1. Added OnchainKit styles to `globals.css`
2. Created a new `providers.tsx` file (not shown in the diff, but mentioned in the instructions)
3. Updated `layout.tsx` to wrap the app with the `Providers` component

These changes will enable the use of OnchainKit components and functionality in our project.

### Details:

- In `globals.css`, we've added the import for OnchainKit styles:
  ```css
  @import '@coinbase/onchainkit/styles.css';
  ```

- In `layout.tsx`, we've imported the `Providers` component and wrapped the children with it:
  ```tsx
  import { Providers } from './providers';
  // ...
  <Providers>
    {children}
  </Providers>
  ```

### Next steps:
1. Create the `providers.tsx` file as described in the instructions
2. Install the `@coinbase/onchainkit` package
3. Set up the `.env` file with the OnchainKit API key

Please review these changes and let me know if any adjustments are needed.