### PR TITLE
Add sign in and sign up functionality using Clerk

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ClerkProvider } from '@clerk/nextjs';
 import "./globals.css";
 
 const geistSans = Geist({
@@ -23,12 +24,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
-    </html>
+    <ClerkProvider>
+      <html lang="en">
+        <body
+          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        >
+          {children}
+        </body>
+      </html>
+    </ClerkProvider>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,18 @@
 import Image from "next/image";
+import { UserButton } from '@clerk/nextjs';
+import Link from 'next/link';
 
 export default function Home() {
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+      <header className="flex justify-between items-center w-full max-w-4xl">
+        <div></div>
+        <div className="flex gap-4 items-center">
+          <Link href="/sign-in" className="text-sm hover:underline">Sign In</Link>
+          <Link href="/sign-up" className="text-sm hover:underline">Sign Up</Link>
+          <UserButton afterSignOutUrl="/" />
+        </div>
+      </header>
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,5 @@
+import { SignIn } from '@clerk/nextjs';
+
+export default function SignInPage() {
+  return <SignIn />;
+}

--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,5 @@
+import { SignUp } from '@clerk/nextjs';
+
+export default function SignUpPage() {
+  return <SignUp />;
+}


### PR DESCRIPTION
This pull request implements sign in and sign up functionality using Clerk authentication in our Next.js application. The changes include:

1. Wrapping the root layout with `ClerkProvider` to enable Clerk authentication throughout the app.
2. Adding a header to the home page with Sign In and Sign Up links, as well as a `UserButton` component for signed-in users.

These changes lay the groundwork for user authentication in our application. To complete the implementation, we should also:

1. Install the `@clerk/nextjs` package.
2. Set up the required environment variables (`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY`).
3. Create dedicated sign-in and sign-up pages.
4. Implement route protection for authenticated-only pages.

Please review the changes and let me know if any adjustments are needed.